### PR TITLE
Add Circle-CI Integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 vvvv
 ====
 
-|Build Status2| |Build Status| |PyPI| 
+|Build Status| |Build Status2| |Build Status3| |PyPI| 
 
 About
 -----
@@ -40,5 +40,7 @@ See `LICENSE <./LICENSE>`__
    :target: https://travis-ci.org/Djiit/vvvv
 .. |Build Status2| image:: https://drone.io/github.com/Djiit/vvvv/status.png
    :target: https://drone.io/github.com/Djiit/vvvv/latest
+.. |Build Status3| image:: https://circleci.com/gh/Djiit/vvvv/tree/master.svg?style=svg
+   :target: https://circleci.com/gh/Djiit/vvvv/tree/master
 .. |PyPI| image:: https://img.shields.io/pypi/v/vvvv.svg
    :target: https://pypi.python.org/pypi/vvvv

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - py.test

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 test:
   override:
-    - py.test
+    - tox

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+dependencies:
+  override:
+    - pip install tox tox-pyenv
+    - pyenv local 3.4.3 3.5.0
+
 test:
   override:
     - tox

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = testing doc

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = testing doc
+testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py34, py35
+skip_missing_interpreters=True
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Another brick in the CI Wall.

Add py.test configuration in pytest.ini to avoid testing the generated `venv/` folder.
Add circle.yml, overriding pre / test command to focus on tox testing.
Add status badge in README.rst.
